### PR TITLE
Hide keyboard when launching set timer view

### DIFF
--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownActivity.java
@@ -129,8 +129,6 @@ public class CountdownActivity extends Activity {
         @Override
         public void onFinish() {
             CountdownActivity.this.prepareReturnToSender();
-
-            return;
         }
     }
 }

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/MainActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/MainActivity.java
@@ -27,32 +27,21 @@ import android.view.View;
 import android.widget.NumberPicker;
 import android.widget.Toast;
 
+import java.util.Calendar;
+import java.util.Date;
+
 /**
- * The launching point for the sleep timer. Launches either {@link SetTimerActivity} or {@link CountdownActivity}
- * depending on whether the sleep timer is currently running.
+ * The launching point for the sleep timer.
  *
  * @author Joel Andrews
  */
 public class MainActivity extends Activity {
 
-    // TODO Move these into a common base class of SetTimerActivity and CountdownActivity
-    public static final int MIN_HOURS = 0;
-    public static final int MAX_HOURS = 9;
-    public static final int MIN_MINUTES = 0;
-    public static final int MAX_MINUTES = 59;
-
     @Override
     protected void onResume() {
         super.onResume();
 
-        Intent intent;
-        if (TimerManager.getInstance(this).getScheduledTime() != null) {
-            intent = new Intent(this, CountdownActivity.class);
-        } else {
-            intent = new Intent(this, SetTimerActivity.class);
-        }
-
-        startActivityForResult(intent, 0);
+        launchActivity();
     }
 
     @Override
@@ -67,5 +56,24 @@ public class MainActivity extends Activity {
             default:
                 throw new IllegalArgumentException("Argument resultCode must be be either RESULT_OK or RESULT_CANCELED");
         }
+    }
+
+    /**
+     * Launches the appropriate activity depending on whether the sleep timer is currently running
+     * ({@link CountdownActivity}) or not ({@link SetTimerActivity}).
+     */
+    private void launchActivity() {
+        Calendar calendarNow = Calendar.getInstance();
+        Date scheduledTime = TimerManager.getInstance(this).getScheduledTime();
+
+        Intent intent;
+        if (scheduledTime == null || scheduledTime.getTime() <= calendarNow.getTimeInMillis()) {
+            // If the scheduled time occurs in the past, we treat it as if the timer is no longer running
+            intent = new Intent(this, SetTimerActivity.class);
+        } else {
+            intent = new Intent(this, CountdownActivity.class);
+        }
+
+        startActivityForResult(intent, 0);
     }
 }

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/MainActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/MainActivity.java
@@ -17,15 +17,7 @@ limitations under the License.
 package com.oldsneerjaw.sleeptimer;
 
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.os.Bundle;
 import android.app.Activity;
-import android.preference.PreferenceManager;
-import android.util.Log;
-import android.view.Menu;
-import android.view.View;
-import android.widget.NumberPicker;
-import android.widget.Toast;
 
 import java.util.Calendar;
 import java.util.Date;

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
@@ -38,6 +38,11 @@ public class SetTimerActivity extends Activity {
     private static final String HOURS_KEY = MainActivity.class.getName() + ".hours";
     private static final String MINUTES_KEY = MainActivity.class.getName() + ".minutes";
 
+    private static final int MIN_HOURS = 0;
+    private static final int MAX_HOURS = 9;
+    private static final int MIN_MINUTES = 0;
+    private static final int MAX_MINUTES = 59;
+
     // By default, the timer will be set to one hour
     private static final int DEFAULT_HOURS = 1;
     private static final int DEFAULT_MINUTES = 0;
@@ -55,13 +60,13 @@ public class SetTimerActivity extends Activity {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
         hoursPicker = (NumberPicker) findViewById(R.id.hours_picker);
-        hoursPicker.setMinValue(MainActivity.MIN_HOURS);
-        hoursPicker.setMaxValue(MainActivity.MAX_HOURS);
+        hoursPicker.setMinValue(MIN_HOURS);
+        hoursPicker.setMaxValue(MAX_HOURS);
         hoursPicker.setValue(sharedPreferences.getInt(HOURS_KEY, DEFAULT_HOURS));
 
         minutesPicker = (NumberPicker) findViewById(R.id.minutes_picker);
-        minutesPicker.setMinValue(MainActivity.MIN_MINUTES);
-        minutesPicker.setMaxValue(MainActivity.MAX_MINUTES);
+        minutesPicker.setMinValue(MIN_MINUTES);
+        minutesPicker.setMaxValue(MAX_MINUTES);
         minutesPicker.setValue(sharedPreferences.getInt(MINUTES_KEY, DEFAULT_MINUTES));
     }
 

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
@@ -23,6 +23,7 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.NumberPicker;
 import android.widget.Toast;
 
@@ -56,6 +57,10 @@ public class SetTimerActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_set_timer);
+
+        // Prevent the soft keyboard from appearing until explicitly launched by the user
+        // Source: http://stackoverflow.com/a/2059394
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/TimerManager.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/TimerManager.java
@@ -132,16 +132,15 @@ public class TimerManager {
     /**
      * Returns the time that the timer is set to expire.
      *
-     * @return A {@link Date}, or null if no time is currently set
+     * @return A {@link Date}, or null if no timer is currently set
      */
     public Date getScheduledTime() {
+        if (!sharedPreferences.contains(SCHEDULED_TIME_KEY)) {
+            return null;
+        }
+
         long millis = sharedPreferences.getLong(SCHEDULED_TIME_KEY, Long.MIN_VALUE);
 
-        if (millis < Calendar.getInstance().getTimeInMillis()) {
-            // The time is set in the past; treat it as though nothing is scheduled
-            return null;
-        } else {
-            return new Date(millis);
-        }
+        return new Date(millis);
     }
 }

--- a/SleepTimer/src/main/res/layout/activity_countdown.xml
+++ b/SleepTimer/src/main/res/layout/activity_countdown.xml
@@ -13,37 +13,27 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical|center_horizontal"
-    android:orientation="vertical"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context=".CountdownActivity">
 
-    <TableLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+    <TableRow>
+        <TextView
+            android:id="@+id/time_remaining_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/countdown_timer_text_size" />
+    </TableRow>
+    <TableRow>
+        <Button
+            android:id="@+id/cancel_timer_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="stopTimer"
+            android:text="@string/cancel_timer_button_label" />
+    </TableRow>
 
-        <TableRow>
-            <TextView
-                android:id="@+id/time_remaining_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/countdown_timer_text_size" />
-        </TableRow>
-        <TableRow>
-            <Button
-                android:id="@+id/cancel_timer_button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:onClick="stopTimer"
-                android:text="@string/cancel_timer_button_label" />
-        </TableRow>
-    </TableLayout>
-
-</LinearLayout>
+</TableLayout>

--- a/SleepTimer/src/main/res/layout/activity_set_timer.xml
+++ b/SleepTimer/src/main/res/layout/activity_set_timer.xml
@@ -13,62 +13,61 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical|center_horizontal"
-    android:orientation="vertical"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context=".SetTimerActivity">
 
-    <TableLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+    <TableRow>
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal|center_vertical"
+            android:orientation="horizontal"
+            tools:ignore="UselessParent">
+            <!--
+            NOTE: Lint mistakenly reports this LinearLayout as useless; however, it provides weight for the start button
+            in the next row to expand to the full width of the table. Using tools:ignore to suppress the warning for
+            this one instance. Source: http://tools.android.com/recent/ignoringlintwarnings
+             -->
 
-        <TableRow>
-            <LinearLayout
+            <NumberPicker
+                android:id="@+id/hours_picker"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal|center_vertical"
-                android:orientation="horizontal">
+                android:textSize="@dimen/set_timer_hour_minute_unit_text_size"
+                android:text="@string/hours_label" />
 
-                <NumberPicker
-                    android:id="@+id/hours_picker"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="@dimen/set_timer_hour_minute_unit_text_size"
-                    android:text="@string/hours_label" />
+            <Space
+                android:layout_width="@dimen/set_timer_spacer_size"
+                android:layout_height="match_parent" />
 
-                <Space
-                    android:layout_width="@dimen/set_timer_spacer_size"
-                    android:layout_height="match_parent" />
-
-                <NumberPicker
-                    android:id="@+id/minutes_picker"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="@dimen/set_timer_hour_minute_unit_text_size"
-                    android:text="@string/minutes_label" />
-            </LinearLayout>
-        </TableRow>
-        <TableRow>
-            <Button
-                android:id="@+id/start_timer_button"
-                android:layout_width="match_parent"
+            <NumberPicker
+                android:id="@+id/minutes_picker"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+            <TextView
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:onClick="startTimer"
-                android:text="@string/start_timer_button_label" />
-        </TableRow>
-    </TableLayout>
+                android:textSize="@dimen/set_timer_hour_minute_unit_text_size"
+                android:text="@string/minutes_label" />
+        </LinearLayout>
+    </TableRow>
+    <TableRow>
+        <Button
+            android:id="@+id/start_timer_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="startTimer"
+            android:text="@string/start_timer_button_label" >
 
-</LinearLayout>
+            <requestFocus />
+        </Button>
+    </TableRow>
+
+</TableLayout>

--- a/SleepTimer/src/main/res/layout/activity_set_timer.xml
+++ b/SleepTimer/src/main/res/layout/activity_set_timer.xml
@@ -43,7 +43,13 @@ limitations under the License.
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:textSize="@dimen/set_timer_hour_minute_unit_text_size"
                     android:text="@string/hours_label" />
+
+                <Space
+                    android:layout_width="@dimen/set_timer_spacer_size"
+                    android:layout_height="match_parent" />
+
                 <NumberPicker
                     android:id="@+id/minutes_picker"
                     android:layout_width="wrap_content"
@@ -51,6 +57,7 @@ limitations under the License.
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:textSize="@dimen/set_timer_hour_minute_unit_text_size"
                     android:text="@string/minutes_label" />
             </LinearLayout>
         </TableRow>

--- a/SleepTimer/src/main/res/values/dimens.xml
+++ b/SleepTimer/src/main/res/values/dimens.xml
@@ -2,5 +2,7 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="set_timer_hour_minute_unit_text_size">12pt</dimen>
+    <dimen name="set_timer_spacer_size">20dp</dimen>
     <dimen name="countdown_timer_text_size">36pt</dimen>
 </resources>


### PR DESCRIPTION
The soft keyboard is no longer opened until explicitly launched by the user on the set timer view
