### PR TITLE
Timer field values always saved on submit

### DIFF
--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
@@ -92,6 +92,11 @@ public class SetTimerActivity extends Activity {
 
         Log.d(LOG_TAG, "Sleep timer started by view " + view.getId());
 
+        // Explicitly clear focus from the number pickers to ensure that the stored values get updated.
+        // Source: http://stackoverflow.com/a/13409571
+        hoursPicker.clearFocus();
+        minutesPicker.clearFocus();
+
         int hours = hoursPicker.getValue();
         int minutes = minutesPicker.getValue();
 


### PR DESCRIPTION
Explicitly clear focus from the hour and minute number pickers to force the views to update their stored values.
