### PR TITLE
Pause Rdio playback

### DIFF
--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiverTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiverTest.java
@@ -1,0 +1,44 @@
+package com.oldsneerjaw.sleeptimer;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.test.AndroidTestCase;
+import android.text.TextUtils;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.mockito.Mockito;
+
+/**
+ * Test cases for {@link PauseMusicReceiver}.
+ *
+ * @author Joel Andrews
+ */
+public class PauseMusicReceiverTest extends AndroidTestCase {
+
+    public void testPauseMusic() {
+        Context mockContext = Mockito.mock(Context.class);
+        TimerManager mockTimerManager = Mockito.mock(TimerManager.class);
+
+        new PauseMusicReceiver().pauseMusic(mockContext, mockTimerManager);
+
+        Mockito.verify(mockContext).startService(Mockito.argThat(new BaseMatcher<Intent>() {
+            @Override
+            public boolean matches(Object o) {
+                Intent candidate = (Intent) o;
+
+                ComponentName component = candidate.getComponent();
+                return TextUtils.equals(PauseMusicService.class.getName(), component.getClassName());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                // In the event of a test failure, this describes what was expected
+                description.appendText("explicit intent to launch " + PauseMusicService.class.getName());
+            }
+        }));
+
+        Mockito.verify(mockTimerManager).cancelTimer();
+    }
+}

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
@@ -1,0 +1,57 @@
+package com.oldsneerjaw.sleeptimer;
+
+import android.media.AudioManager;
+import android.test.AndroidTestCase;
+
+import org.mockito.Mockito;
+
+/**
+ * Test cases for {@link PauseMusicService}.
+ */
+public class PauseMusicServiceTest extends AndroidTestCase {
+
+    private AudioManager mockAudioManager;
+    private AudioManager.OnAudioFocusChangeListener mockListener;
+    private PauseMusicService service;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        mockAudioManager = Mockito.mock(AudioManager.class);
+        mockListener = Mockito.mock(AudioManager.OnAudioFocusChangeListener.class);
+        PauseMusicNotifier mockNotifier = Mockito.mock(PauseMusicNotifier.class);
+
+        service = new PauseMusicService();
+        service.onCreate(mockAudioManager, mockListener, mockNotifier);
+    }
+
+    public void testPauseMusicPlayback_Success() {
+        Mockito.when(mockAudioManager.requestAudioFocus(mockListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN))
+                .thenReturn(AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
+
+        assertTrue(service.pauseMusicPlayback());
+    }
+
+    public void testPauseMusicPlayback_Failed() {
+        Mockito.when(mockAudioManager.requestAudioFocus(mockListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN))
+                .thenReturn(AudioManager.AUDIOFOCUS_REQUEST_FAILED);
+
+        assertFalse(service.pauseMusicPlayback());
+    }
+
+    public void testOnDestroy() {
+        service.onDestroy();
+
+        Mockito.verify(mockAudioManager).abandonAudioFocus(mockListener);
+    }
+
+    public void testAudioFocusListener() {
+        PauseMusicService mockService = Mockito.mock(PauseMusicService.class);
+        PauseMusicService.AudioFocusListener listener = mockService.new AudioFocusListener();
+
+        listener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS);
+
+        Mockito.verify(mockService).stopAndReleaseAudioFocus();
+    }
+}

--- a/SleepTimer/src/main/AndroidManifest.xml
+++ b/SleepTimer/src/main/AndroidManifest.xml
@@ -22,9 +22,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <receiver android:name="com.oldsneerjaw.sleeptimer.PauseMusicReceiver" />
-
         <activity
             android:name="com.oldsneerjaw.sleeptimer.CountdownActivity"
             android:label="@string/app_name" >
@@ -33,6 +30,10 @@
             android:name="com.oldsneerjaw.sleeptimer.SetTimerActivity"
             android:label="@string/app_name" >
         </activity>
+
+        <receiver android:name="com.oldsneerjaw.sleeptimer.PauseMusicReceiver" />
+
+        <service android:name=".PauseMusicService" android:exported="false"/>
     </application>
 
 </manifest>

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiver.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiver.java
@@ -8,8 +8,6 @@ package com.oldsneerjaw.sleeptimer;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.media.AudioManager;
-import android.util.Log;
 
 /**
  * Handles broadcast events intended to pause music playback indefinitely.
@@ -18,90 +16,23 @@ import android.util.Log;
  */
 public class PauseMusicReceiver extends BroadcastReceiver {
 
-    private static final String LOG_TAG = PauseMusicReceiver.class.getName();
-
     @Override
     public void onReceive(Context context, Intent intent) {
-
-        if (pauseMusicPlayback(context)) {
-            Log.i(LOG_TAG, "Successfully paused music playback");
-
-            notify(context);
-        } else {
-            Log.e(LOG_TAG, "Failed to pause music playback");
-        }
-
-        TimerManager.getInstance(context).cancelTimer();
+        pauseMusic(context, TimerManager.getInstance(context));
     }
 
     /**
      * Pauses all music playback on the device.
      *
-     * @param context The context
+     * @param context The context in which the receiver is running
      *
-     * @return {@code true} if playback was successfully paused; otherwise, {@code false}
+     * @param timerManager The pause music timer manager
      */
-    private boolean pauseMusicPlayback(Context context) {
+    void pauseMusic(Context context, TimerManager timerManager) {
+        // The service will be responsible for actually pausing playback and ensuring it remains paused until explicitly
+        // restarted
+        context.startService(new Intent(context, PauseMusicService.class));
 
-        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-
-        AudioFocusListener listener = new AudioFocusListener(audioManager);
-
-        // A well-behaved media player should relinquish audio focus (i.e. pause playback) when another app requests
-        // focus: http://developer.android.com/training/managing-audio/audio-focus.html#HandleFocusLoss
-        int audioFocusResult = audioManager.requestAudioFocus(listener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-        if (audioFocusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-            Log.d(LOG_TAG, "Audio focus GAINED");
-
-            // Immediately release focus. If the previous owner is well behaved, it will remain paused indefinitely;
-            // if not, then holding onto audio focus will only briefly delay it from resuming playback until this app
-            // is automatically recycled by the OS
-            audioManager.abandonAudioFocus(listener);
-
-            return true;
-        } else {
-            Log.d(LOG_TAG, "Audio focus DENIED");
-
-            return false;
-        }
-    }
-
-    /**
-     * Posts a status bar notification that music playback has been paused.
-     *
-     * @param context The context
-     */
-    private void notify(Context context) {
-        PauseMusicNotifier notifier = new PauseMusicNotifier(context);
-        notifier.postNotification();
-    }
-
-
-    /**
-     * A listener for audio focus change events.
-     */
-    private class AudioFocusListener implements AudioManager.OnAudioFocusChangeListener {
-
-        private AudioManager audioManager;
-
-        public AudioFocusListener(AudioManager audioManager) {
-            this.audioManager = audioManager;
-        }
-
-        @Override
-        public void onAudioFocusChange(int focusChange) {
-
-            switch (focusChange) {
-                case AudioManager.AUDIOFOCUS_GAIN:
-                    Log.d(LOG_TAG, "Audio focus REGAINED");
-                    break;
-                case AudioManager.AUDIOFOCUS_LOSS:
-                    Log.d(LOG_TAG, "Audio focus LOST permanently");
-                    audioManager.abandonAudioFocus(this);
-                    break;
-                default:
-                    Log.d(LOG_TAG, "Audio focus changed: " + focusChange);
-            }
-        }
+        timerManager.cancelTimer();
     }
 }

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicService.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicService.java
@@ -1,0 +1,147 @@
+package com.oldsneerjaw.sleeptimer;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.util.Log;
+
+/**
+ * <p>
+ * A service that pauses all music playback on the device and ensures that it remains paused until playback is
+ * explicitly started again.
+ * </p>
+ * <p>
+ * Certain music apps (e.g. Rdio) do not adhere to Android's guidelines for
+ * <a href="http://developer.android.com/training/managing-audio/audio-focus.html#HandleFocusLoss">
+ *     handling the loss of audio focus
+ * </a>
+ * and will immediately reclaim audio focus as soon as it's available; therefore, this service claims audio focus and
+ * attempts to keep it until another app explicitly requests audio focus. See
+ * <a href="https://github.com/rdio/api/issues/90">Rdio API issue #90</a> for a more detailed description of the
+ * problem.
+ * </p>
+ *
+ * @author Joel Andrews
+ */
+public class PauseMusicService extends IntentService {
+
+    private static final String LOG_TAG = PauseMusicService.class.getName();
+
+    private AudioManager audioManager;
+    private AudioManager.OnAudioFocusChangeListener listener;
+    private PauseMusicNotifier notifier;
+
+    /**
+     * Constructs an instance of {@link PauseMusicService}.
+     */
+    public PauseMusicService() {
+        super(PauseMusicService.class.getName());
+    }
+
+    @Override
+    public void onCreate() {
+        onCreate(
+                (AudioManager) getApplicationContext().getSystemService(Context.AUDIO_SERVICE),
+                new AudioFocusListener(),
+                new PauseMusicNotifier(getApplicationContext()));
+    }
+
+    /**
+     * Initializes the service's dependencies.
+     *
+     * @param audioManager The audio manager to use
+     * @param listener The audio focus change listener to use
+     * @param notifier The pause music notifier to use
+     */
+    void onCreate(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener listener, PauseMusicNotifier notifier) {
+        super.onCreate();
+
+        this.audioManager = audioManager;
+        this.listener = listener;
+        this.notifier = notifier;
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        // Attempt to hold onto audio focus indefinitely; only if another app explicitly requests audio focus
+        // will this service willingly let it go
+        if (pauseMusicPlayback()) {
+            Log.i(LOG_TAG, "Successfully paused music playback");
+
+            notifier.postNotification();
+
+            synchronized (this) {
+                try {
+                    // Wait indefinitely to ensure that the service is not recycled and that it keeps audio focus
+                    wait();
+                } catch (InterruptedException ex) {
+                    Log.d(LOG_TAG, "Service interrupted", ex);
+
+                    stopAndReleaseAudioFocus();
+                }
+            }
+        } else {
+            Log.e(LOG_TAG, "Failed to pause music playback");
+        }
+    }
+
+    /**
+     * Pauses all music playback on the device.
+     *
+     * @return {@code true} if playback was successfully paused; otherwise, {@code false}
+     */
+    boolean pauseMusicPlayback() {
+        // Taking audio focus should force other apps to pause/stopAndReleaseAudioFocus music playback
+        int audioFocusResult =
+                audioManager.requestAudioFocus(listener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+        if (audioFocusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Stops the service and releases audio focus.
+     */
+    void stopAndReleaseAudioFocus() {
+        audioManager.abandonAudioFocus(listener);
+        stopSelf();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        if (listener != null && audioManager != null) {
+            audioManager.abandonAudioFocus(listener);
+            listener = null;
+            audioManager = null;
+        }
+    }
+
+    /**
+     * A listener for audio focus change events.
+     */
+    class AudioFocusListener implements AudioManager.OnAudioFocusChangeListener {
+
+        @Override
+        public void onAudioFocusChange(int focusChange) {
+
+            switch (focusChange) {
+                case AudioManager.AUDIOFOCUS_LOSS:
+                    Log.d(LOG_TAG, "Audio focus lost permanently");
+
+                    // Since audio focus has been permanently taken by another process (e.g. the user explicitly
+                    // restarted music playback), the service can be stopped and audio focus released so this process
+                    // does not automatically reclaim audio focus when/if the new owner relinquishes it
+                    stopAndReleaseAudioFocus();
+
+                    break;
+                default:
+                    Log.d(LOG_TAG, "Audio focus changed: " + focusChange);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented a service to handle requesting and holding onto audio focus indefinitely so that Rdio playback remains paused. See [issue #18](https://github.com/OldSneerJaw/sleep-timer/issues/18) for more info.
