### PR TITLE
Sticky service

### DIFF
--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
@@ -12,6 +12,7 @@ public class PauseMusicServiceTest extends AndroidTestCase {
 
     private AudioManager mockAudioManager;
     private AudioManager.OnAudioFocusChangeListener mockListener;
+    private PauseMusicNotifier mockNotifier;
     private PauseMusicService service;
 
     @Override
@@ -20,24 +21,28 @@ public class PauseMusicServiceTest extends AndroidTestCase {
 
         mockAudioManager = Mockito.mock(AudioManager.class);
         mockListener = Mockito.mock(AudioManager.OnAudioFocusChangeListener.class);
-        PauseMusicNotifier mockNotifier = Mockito.mock(PauseMusicNotifier.class);
+        mockNotifier = Mockito.mock(PauseMusicNotifier.class);
 
         service = new PauseMusicService();
         service.onCreate(mockAudioManager, mockListener, mockNotifier);
     }
 
-    public void testPauseMusicPlayback_Success() {
+    public void testPauseAndNotify_Success() {
         Mockito.when(mockAudioManager.requestAudioFocus(mockListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN))
                 .thenReturn(AudioManager.AUDIOFOCUS_REQUEST_GRANTED);
 
-        assertTrue(service.pauseMusicPlayback());
+        assertTrue(service.pauseAndNotify());
+
+        Mockito.verify(mockNotifier).postNotification();
     }
 
-    public void testPauseMusicPlayback_Failed() {
+    public void testPauseAndNotify_Failed() {
         Mockito.when(mockAudioManager.requestAudioFocus(mockListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN))
                 .thenReturn(AudioManager.AUDIOFOCUS_REQUEST_FAILED);
 
-        assertFalse(service.pauseMusicPlayback());
+        assertFalse(service.pauseAndNotify());
+
+        Mockito.verifyNoMoreInteractions(mockNotifier);
     }
 
     public void testOnDestroy() {

--- a/SleepTimer/src/main/AndroidManifest.xml
+++ b/SleepTimer/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
 
         <receiver android:name="com.oldsneerjaw.sleeptimer.PauseMusicReceiver" />
 
-        <service android:name=".PauseMusicService" android:exported="false"/>
+        <service android:name=".PauseMusicService" android:exported="false" android:process=":SleepTimerService"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Make the PauseMusicService a [sticky service](http://stackoverflow.com/a/12017536) to prevent it from being recycled by the OS.  Intended to resolve [issue #24](https://github.com/OldSneerJaw/sleep-timer/issues/24).
