### PR TITLE
Removed settings menu actions

### DIFF
--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownActivity.java
@@ -40,13 +40,6 @@ public class CountdownActivity extends Activity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.countdown, menu);
-        return true;
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
 

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/SetTimerActivity.java
@@ -64,14 +64,6 @@ public class SetTimerActivity extends Activity {
         minutesPicker.setValue(sharedPreferences.getInt(MINUTES_KEY, DEFAULT_MINUTES));
     }
 
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.set_timer, menu);
-        return true;
-    }
-
     /**
      * Starts a countdown timer based on the current settings.
      *

--- a/SleepTimer/src/main/res/menu/countdown.xml
+++ b/SleepTimer/src/main/res/menu/countdown.xml
@@ -1,6 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:id="@+id/action_settings"
-        android:title="@string/action_settings"
-        android:orderInCategory="100"
-        android:showAsAction="never" />
-</menu>

--- a/SleepTimer/src/main/res/menu/main.xml
+++ b/SleepTimer/src/main/res/menu/main.xml
@@ -1,6 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:id="@+id/action_settings"
-        android:title="@string/action_settings"
-        android:orderInCategory="100"
-        android:showAsAction="never" />
-</menu>

--- a/SleepTimer/src/main/res/menu/set_timer.xml
+++ b/SleepTimer/src/main/res/menu/set_timer.xml
@@ -1,6 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:id="@+id/action_settings"
-        android:title="@string/action_settings"
-        android:orderInCategory="100"
-        android:showAsAction="never" />
-</menu>

--- a/SleepTimer/src/main/res/values/strings.xml
+++ b/SleepTimer/src/main/res/values/strings.xml
@@ -2,14 +2,13 @@
 <resources>
 
     <string name="app_name">Sleep Timer</string>
-    <string name="action_settings">Settings</string>
     <string name="start_timer_button_label">Start</string>
     <string name="cancel_timer_button_label">Cancel</string>
     <string name="timer_started">Sleep timer started</string>
     <string name="timer_cancelled">Sleep timer cancelled</string>
     <string name="hours_label">h</string>
     <string name="minutes_label">m</string>
-    <string name="paused_music_notification_title">Sleep Timer - Music stopped</string>
+    <string name="paused_music_notification_title">Sleep Timer - Music Paused</string>
     <string name="paused_music_notification_text">Good night!</string>
 
 </resources>


### PR DESCRIPTION
The settings menu actions were not implemented or required. See [issue #27](https://github.com/OldSneerJaw/sleep-timer/issues/27).
