### PR TITLE
Remove notification when playback resumes

### DIFF
--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifierTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifierTest.java
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2013 Joel Andrews
+Distributed under the MIT License: http://opensource.org/licenses/MIT
+ */
+
+package com.oldsneerjaw.sleeptimer;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.res.Resources;
+import android.support.v4.app.NotificationCompat;
+import android.test.AndroidTestCase;
+import android.text.TextUtils;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.mockito.Mockito;
+
+/**
+ * Test cases for {@link PauseMusicNotifierTest}.
+ *
+ * @author Joel Andrews
+ */
+public class PauseMusicNotifierTest extends AndroidTestCase {
+
+    private static final int NOTIFICATION_ID = 1;
+
+    private static final String NOTIFICATION_TITLE = "foo";
+    private static final String NOTIFICATION_TEXT = "bar";
+
+    private Context mockContext;
+    private NotificationManager mockNotificationManager;
+    private Resources mockResources;
+    private PauseMusicNotifier notifier;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        mockContext = Mockito.mock(Context.class);
+        Mockito.when(mockContext.getPackageName()).thenReturn("com.oldsneerjaw.sleeptimer");
+        Mockito.when(mockContext.getApplicationContext()).thenReturn(mockContext);
+
+        mockNotificationManager = Mockito.mock(NotificationManager.class);
+
+        mockResources = Mockito.mock(Resources.class);
+        Mockito.when(mockResources.getString(R.string.paused_music_notification_title)).thenReturn(NOTIFICATION_TITLE);
+        Mockito.when(mockResources.getString(R.string.paused_music_notification_text)).thenReturn(NOTIFICATION_TEXT);
+
+        notifier = new PauseMusicNotifier(mockContext, mockNotificationManager, mockResources);
+    }
+
+    public void testPostNotification() {
+        notifier.postNotification();
+
+        Mockito.verify(mockNotificationManager).notify(
+                Mockito.eq(NOTIFICATION_ID),
+                Mockito.argThat(new BaseMatcher<Notification>() {
+                    @Override
+                    public boolean matches(Object o) {
+                        if (!(o instanceof Notification)) {
+                            return false;
+                        }
+
+                        Notification candidate = (Notification) o;
+
+                        return TextUtils.equals(NOTIFICATION_TITLE, candidate.tickerText)
+                                && (candidate.icon == R.drawable.ic_launcher)
+                                && (candidate.priority == NotificationCompat.PRIORITY_DEFAULT)
+                                && (candidate.contentIntent != null)
+                                && ((candidate.flags & Notification.FLAG_AUTO_CANCEL) != 0);
+                    }
+
+                    @Override
+                    public void describeTo(Description description) {
+                        // Describe the notification that was expected in the event of test failure
+                        description.appendText("a notification with the correct title, icon, default priority, a pending intent and set to auto cancel");
+                    }
+                })
+        );
+    }
+
+    public void testCancelNotification() {
+        notifier.cancelNotification();
+
+        Mockito.verify(mockNotificationManager).cancel(NOTIFICATION_ID);
+    }
+}

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiverTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiverTest.java
@@ -1,3 +1,8 @@
+/*
+Copyright (c) 2013 Joel Andrews
+Distributed under the MIT License: http://opensource.org/licenses/MIT
+ */
+
 package com.oldsneerjaw.sleeptimer;
 
 import android.content.ComponentName;

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
@@ -1,3 +1,8 @@
+/*
+Copyright (c) 2013 Joel Andrews
+Distributed under the MIT License: http://opensource.org/licenses/MIT
+ */
+
 package com.oldsneerjaw.sleeptimer;
 
 import android.media.AudioManager;

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifier.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifier.java
@@ -20,22 +20,40 @@ import android.support.v4.app.NotificationCompat;
  */
 public class PauseMusicNotifier {
 
-    private static final String NOTIFICATION_TAG = PauseMusicNotifier.class.getName() + ".MusicPaused";
-    private static final int NOTIFICATION_ID = 0;
+    private static final int NOTIFICATION_ID = 1;
 
-    private Context context;
+    private final Context context;
+    private final NotificationManager notificationManager;
+    private final Resources resources;
 
     /**
      * Constructs an instance of {@link PauseMusicNotifier}.
      *
-     * @param context The context. Must not be null.
+     * @param context The context
      */
     public PauseMusicNotifier(Context context) {
+        this(context, (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE), context.getResources());
+    }
+
+    /**
+     * Constructs an instance of {@link PauseMusicNotifier}.
+     *
+     * @param context The context
+     * @param notificationManager The system notification manager
+     * @param resources The app's resources
+     */
+    PauseMusicNotifier(Context context, NotificationManager notificationManager, Resources resources) {
         if (context == null) {
             throw new NullPointerException("Argument context cannot be null");
+        } else if (notificationManager == null) {
+            throw new NullPointerException("Argument notificationManager cannot be null");
+        } else if (resources == null) {
+            throw new NullPointerException("Argument resources cannot be null");
         }
 
         this.context = context.getApplicationContext();
+        this.notificationManager = notificationManager;
+        this.resources = resources;
     }
 
     /**
@@ -44,8 +62,6 @@ public class PauseMusicNotifier {
      * @return A {@link Notification}
      */
     private Notification create() {
-        Resources resources = context.getResources();
-
         String title = resources.getString(R.string.paused_music_notification_title);
         String text = resources.getString(R.string.paused_music_notification_text);
 
@@ -70,8 +86,13 @@ public class PauseMusicNotifier {
     public void postNotification() {
         Notification notification = create();
 
-        NotificationManager notificationManager =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.notify(NOTIFICATION_TAG, NOTIFICATION_ID, notification);
+        notificationManager.notify(NOTIFICATION_ID, notification);
+    }
+
+    /**
+     * Cancels and removes the music paused notification, in any, from the system status bar.
+     */
+    public void cancelNotification() {
+        notificationManager.cancel(NOTIFICATION_ID);
     }
 }

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicService.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicService.java
@@ -1,3 +1,8 @@
+/*
+Copyright (c) 2013 Joel Andrews
+Distributed under the MIT License: http://opensource.org/licenses/MIT
+ */
+
 package com.oldsneerjaw.sleeptimer;
 
 import android.app.IntentService;
@@ -138,8 +143,11 @@ public class PauseMusicService extends IntentService {
     public void onDestroy() {
         super.onDestroy();
 
+        // Because this is a sticky service, we should generally only get here if music playback has been manually
+        // restarted or the user has manually killed the service's process; in any event, release all resources
         audioManager.abandonAudioFocus(listener);
         isMusicPaused = false;
+        notifier.cancelNotification();
 
         synchronized (syncLock) {
             syncLock.notify();


### PR DESCRIPTION
Remove the music paused notification from the status bar when music playback is restarted. See [issue #26](https://github.com/OldSneerJaw/sleep-timer/issues/26).
