### PR TITLE
Target Android API Level 18

### DIFF
--- a/SleepTimer/build.gradle
+++ b/SleepTimer/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "17.0.0"
+    compileSdkVersion 18
+    buildToolsVersion "18.0.1"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 17
+        targetSdkVersion 18
     }
 }

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/AndroidMockingTestCase.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/AndroidMockingTestCase.java
@@ -1,7 +1,35 @@
+/*
+Copyright (c) 2013 Joel Andrews
+Distributed under the MIT License: http://opensource.org/licenses/MIT
+ */
+
 package com.oldsneerjaw.sleeptimer;
 
+import android.test.AndroidTestCase;
+
 /**
- * Created by Joel on 15/08/13.
+ * Base class for Android test cases that wish to use Mockito. Exists as a workaround because Mockito 1.9.5 does not
+ * work with Android 4.3. Read more <a href="https://code.google.com/p/dexmaker/issues/detail?id=2">here</a>.
  */
-public class AndroidMockingTestCase {
+public abstract class AndroidMockingTestCase extends AndroidTestCase {
+
+    /**
+     * The system property that stores the location of the cache directory for dexmaker.
+     */
+    private static final String DEXMAKER_CACHE_DIR_PROPERTY = "dexmaker.dexcache";
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        //noinspection ConstantConditions
+        System.setProperty(DEXMAKER_CACHE_DIR_PROPERTY, getContext().getCacheDir().toString());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+        System.clearProperty(DEXMAKER_CACHE_DIR_PROPERTY);
+    }
 }

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/AndroidMockingTestCase.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/AndroidMockingTestCase.java
@@ -1,0 +1,7 @@
+package com.oldsneerjaw.sleeptimer;
+
+/**
+ * Created by Joel on 15/08/13.
+ */
+public class AndroidMockingTestCase {
+}

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/MainActivityTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/MainActivityTest.java
@@ -44,10 +44,10 @@ public class MainActivityTest extends ActivityUnitTestCase<MainActivity> {
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.MILLISECOND, 0);
 
-        calendar.set(2013, 7, 5, 15, 53, 48);
+        calendar.set(2013, Calendar.AUGUST, 5, 15, 53, 48);
         Date now = calendar.getTime();
 
-        calendar.set(2014, 8, 6, 16, 54, 49);
+        calendar.set(2014, Calendar.SEPTEMBER, 6, 16, 54, 49);
         Date scheduledTime = calendar.getTime();
 
         Intent result = activity.getActivityIntent(now, scheduledTime);
@@ -60,10 +60,10 @@ public class MainActivityTest extends ActivityUnitTestCase<MainActivity> {
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.MILLISECOND, 0);
 
-        calendar.set(2013, 7, 5, 15, 53, 48);
+        calendar.set(2013, Calendar.AUGUST, 5, 15, 53, 48);
         Date now = calendar.getTime();
 
-        calendar.set(2012, 6, 4, 14, 52, 47);
+        calendar.set(2012, Calendar.JULY, 4, 14, 52, 47);
         Date scheduledTime = calendar.getTime();
 
         Intent result = activity.getActivityIntent(now, scheduledTime);
@@ -75,7 +75,7 @@ public class MainActivityTest extends ActivityUnitTestCase<MainActivity> {
     public void testGetActivityIntent_PresentScheduledTime() {
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.MILLISECOND, 0);
-        calendar.set(2013, 7, 5, 15, 53, 48);
+        calendar.set(2013, Calendar.AUGUST, 5, 15, 53, 48);
 
         Date now = calendar.getTime();
         Date scheduledTime = calendar.getTime();

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifierTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifierTest.java
@@ -10,7 +10,6 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.res.Resources;
 import android.support.v4.app.NotificationCompat;
-import android.test.AndroidTestCase;
 import android.text.TextUtils;
 
 import org.hamcrest.BaseMatcher;
@@ -22,29 +21,27 @@ import org.mockito.Mockito;
  *
  * @author Joel Andrews
  */
-public class PauseMusicNotifierTest extends AndroidTestCase {
+public class PauseMusicNotifierTest extends AndroidMockingTestCase {
 
     private static final int NOTIFICATION_ID = 1;
 
     private static final String NOTIFICATION_TITLE = "foo";
     private static final String NOTIFICATION_TEXT = "bar";
 
-    private Context mockContext;
     private NotificationManager mockNotificationManager;
-    private Resources mockResources;
     private PauseMusicNotifier notifier;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
 
-        mockContext = Mockito.mock(Context.class);
+        Context mockContext = Mockito.mock(Context.class);
         Mockito.when(mockContext.getPackageName()).thenReturn("com.oldsneerjaw.sleeptimer");
         Mockito.when(mockContext.getApplicationContext()).thenReturn(mockContext);
 
         mockNotificationManager = Mockito.mock(NotificationManager.class);
 
-        mockResources = Mockito.mock(Resources.class);
+        Resources mockResources = Mockito.mock(Resources.class);
         Mockito.when(mockResources.getString(R.string.paused_music_notification_title)).thenReturn(NOTIFICATION_TITLE);
         Mockito.when(mockResources.getString(R.string.paused_music_notification_text)).thenReturn(NOTIFICATION_TEXT);
 

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiverTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicReceiverTest.java
@@ -8,7 +8,6 @@ package com.oldsneerjaw.sleeptimer;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.test.AndroidTestCase;
 import android.text.TextUtils;
 
 import org.hamcrest.BaseMatcher;
@@ -20,7 +19,7 @@ import org.mockito.Mockito;
  *
  * @author Joel Andrews
  */
-public class PauseMusicReceiverTest extends AndroidTestCase {
+public class PauseMusicReceiverTest extends AndroidMockingTestCase {
 
     public void testPauseMusic() {
         Context mockContext = Mockito.mock(Context.class);

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicServiceTest.java
@@ -6,14 +6,13 @@ Distributed under the MIT License: http://opensource.org/licenses/MIT
 package com.oldsneerjaw.sleeptimer;
 
 import android.media.AudioManager;
-import android.test.AndroidTestCase;
 
 import org.mockito.Mockito;
 
 /**
  * Test cases for {@link PauseMusicService}.
  */
-public class PauseMusicServiceTest extends AndroidTestCase {
+public class PauseMusicServiceTest extends AndroidMockingTestCase {
 
     private AudioManager mockAudioManager;
     private AudioManager.OnAudioFocusChangeListener mockListener;

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/TimerManagerTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/TimerManagerTest.java
@@ -9,7 +9,6 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.test.AndroidTestCase;
 
 import org.hamcrest.core.Is;
 import org.mockito.Mockito;
@@ -21,7 +20,7 @@ import java.util.Date;
  *
  * @author Joel Andrews
  */
-public class TimerManagerTest extends AndroidTestCase {
+public class TimerManagerTest extends AndroidMockingTestCase {
 
     private static final String SCHEDULED_TIME_KEY = "com.oldsneerjaw.sleeptimer.TimerManager.scheduledTime";
 
@@ -83,8 +82,8 @@ public class TimerManagerTest extends AndroidTestCase {
     }
 
     public void testSetTimer() {
-        int hours = 1;
-        int minutes = 10;
+        final int hours = 1;
+        final int minutes = 10;
         timerManager.setTimer(hours, minutes);
 
         Mockito.verify(mockAlarmManager).set(
@@ -110,7 +109,7 @@ public class TimerManagerTest extends AndroidTestCase {
     }
 
     public void testGetScheduledTime_PreferenceSet() {
-        long expectedTimeMs = 47382472;
+        final long expectedTimeMs = 47382472;
 
         Mockito.when(mockPreferences.contains(SCHEDULED_TIME_KEY)).thenReturn(true);
         Mockito.when(mockPreferences.getLong(Mockito.argThat(Is.is(SCHEDULED_TIME_KEY)), Mockito.anyLong()))

--- a/SleepTimer/src/main/AndroidManifest.xml
+++ b/SleepTimer/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="17" />
+        android:targetSdkVersion="18" />
 
     <application
         android:allowBackup="true"

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/MainActivity.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/MainActivity.java
@@ -8,7 +8,6 @@ package com.oldsneerjaw.sleeptimer;
 import android.content.Intent;
 import android.app.Activity;
 
-import java.util.Calendar;
 import java.util.Date;
 
 /**

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicService.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/PauseMusicService.java
@@ -134,11 +134,7 @@ public class PauseMusicService extends IntentService {
         // Taking audio focus should force other apps to pause/stop music playback
         int audioFocusResult =
                 audioManager.requestAudioFocus(listener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-        if (audioFocusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-            return true;
-        } else {
-            return false;
-        }
+        return audioFocusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
 
     @Override


### PR DESCRIPTION
Build now targets API Level 18 (Android 4.3). Fixed Mockito support on 4.3 devices.

Resolves [issue #31](https://github.com/OldSneerJaw/sleep-timer/issues/31).
