### PR TITLE
Show only time in countdown notification

### DIFF
--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/CountdownNotifierTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/CountdownNotifierTest.java
@@ -51,9 +51,9 @@ public class CountdownNotifierTest extends AndroidMockingTestCase {
         Mockito.when(mockResources.getString(R.string.countdown_notification_title)).thenReturn(NOTIFICATION_TITLE);
         Mockito.when(mockResources.getString(R.string.countdown_notification_text)).thenReturn(NOTIFICATION_TEXT);
 
-        DateFormat countdownEndsDateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.LONG, Locale.ENGLISH);
+        DateFormat countdownTimeFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
 
-        notifier = new CountdownNotifier(mockContext, mockNotificationManager, mockResources, countdownEndsDateFormat);
+        notifier = new CountdownNotifier(mockContext, mockNotificationManager, mockResources, countdownTimeFormat);
     }
 
     public void testGetInstance_EqualContextsReturnSameInstance() {

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/CountdownNotifierTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/CountdownNotifierTest.java
@@ -20,7 +20,6 @@ import org.mockito.Mockito;
 
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.Locale;
 
 /**
  * Test cases for {@link CountdownNotifier}.
@@ -35,6 +34,7 @@ public class CountdownNotifierTest extends AndroidMockingTestCase {
     private static final String NOTIFICATION_TEXT = "bar";
 
     private NotificationManager mockNotificationManager;
+    private CountdownNotifier.TimeFormatFactory mockCountdownTimeFormatFactory;
     private CountdownNotifier notifier;
 
     @Override
@@ -51,9 +51,11 @@ public class CountdownNotifierTest extends AndroidMockingTestCase {
         Mockito.when(mockResources.getString(R.string.countdown_notification_title)).thenReturn(NOTIFICATION_TITLE);
         Mockito.when(mockResources.getString(R.string.countdown_notification_text)).thenReturn(NOTIFICATION_TEXT);
 
-        DateFormat countdownTimeFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
+        mockCountdownTimeFormatFactory = Mockito.mock(CountdownNotifier.TimeFormatFactory.class);
+        Mockito.when(mockCountdownTimeFormatFactory.getTimeFormat())
+                .thenReturn(DateFormat.getTimeInstance(DateFormat.SHORT));
 
-        notifier = new CountdownNotifier(mockContext, mockNotificationManager, mockResources, countdownTimeFormat);
+        notifier = new CountdownNotifier(mockContext, mockNotificationManager, mockResources, mockCountdownTimeFormatFactory);
     }
 
     public void testGetInstance_EqualContextsReturnSameInstance() {
@@ -89,6 +91,7 @@ public class CountdownNotifierTest extends AndroidMockingTestCase {
 
         notifier.postNotification(countdownEnds);
 
+        Mockito.verify(mockCountdownTimeFormatFactory).getTimeFormat();
         Mockito.verify(mockNotificationManager).notify(
                 Mockito.eq(NOTIFICATION_ID),
                 Mockito.argThat(new BaseMatcher<Notification>() {

--- a/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifierTest.java
+++ b/SleepTimer/src/instrumentTest/java/com/oldsneerjaw/sleeptimer/PauseMusicNotifierTest.java
@@ -50,6 +50,34 @@ public class PauseMusicNotifierTest extends AndroidMockingTestCase {
         notifier = new PauseMusicNotifier(mockContext, mockNotificationManager, mockResources);
     }
 
+    public void testGetInstance_EqualContextsReturnSameInstance() {
+        String packageName = "foo";
+
+        Context context1 = Mockito.mock(Context.class);
+        Mockito.when(context1.getPackageName()).thenReturn(packageName);
+
+        Context context2 = Mockito.mock(Context.class);
+        Mockito.when(context2.getPackageName()).thenReturn(packageName);
+
+        PauseMusicNotifier instance1 = PauseMusicNotifier.get(context1);
+        PauseMusicNotifier instance2 = PauseMusicNotifier.get(context2);
+
+        assertSame(instance1, instance2);
+    }
+
+    public void testGetInstance_DifferentContextsReturnDifferentInstances() {
+        Context context1 = Mockito.mock(Context.class);
+        Mockito.when(context1.getPackageName()).thenReturn("foo");
+
+        Context context2 = Mockito.mock(Context.class);
+        Mockito.when(context2.getPackageName()).thenReturn("bar");
+
+        PauseMusicNotifier instance1 = PauseMusicNotifier.get(context1);
+        PauseMusicNotifier instance2 = PauseMusicNotifier.get(context2);
+
+        assertNotSame(instance1, instance2);
+    }
+
     public void testPostNotification() {
         notifier.postNotification();
 

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownNotifier.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownNotifier.java
@@ -37,7 +37,7 @@ public class CountdownNotifier {
     private final Context context;
     private final NotificationManager notificationManager;
     private final Resources resources;
-    private final DateFormat countdownEndDateFormat;
+    private final DateFormat countdownTimeFormat;
 
     /**
      * Constructs an instance of {@link CountdownNotifier}.
@@ -49,7 +49,7 @@ public class CountdownNotifier {
                 context,
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE),
                 context.getResources(),
-                DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+                DateFormat.getTimeInstance(DateFormat.SHORT)
         );
     }
 
@@ -60,18 +60,18 @@ public class CountdownNotifier {
      * @param context The context
      * @param notificationManager The system notification manager
      * @param resources The app's resources
-     * @param countdownEndDateFormat The date and time format to use for the countdown end date and time
+     * @param countdownTimeFormat The time format to use for the countdown
      */
     CountdownNotifier(
             Context context,
             NotificationManager notificationManager,
             Resources resources,
-            DateFormat countdownEndDateFormat) {
+            DateFormat countdownTimeFormat) {
 
         this.context = context.getApplicationContext();
         this.notificationManager = notificationManager;
         this.resources = resources;
-        this.countdownEndDateFormat = countdownEndDateFormat;
+        this.countdownTimeFormat = countdownTimeFormat;
     }
 
     /**
@@ -107,7 +107,7 @@ public class CountdownNotifier {
      * @return A {@link Notification}
      */
     private Notification getNotification(Date countdownEnds) {
-        String countdownEndsString = countdownEndDateFormat.format(countdownEnds);
+        String countdownEndsString = countdownTimeFormat.format(countdownEnds);
         String title = resources.getString(R.string.countdown_notification_title);
         String text = resources.getString(R.string.countdown_notification_text, countdownEndsString);
 

--- a/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownNotifier.java
+++ b/SleepTimer/src/main/java/com/oldsneerjaw/sleeptimer/CountdownNotifier.java
@@ -37,7 +37,7 @@ public class CountdownNotifier {
     private final Context context;
     private final NotificationManager notificationManager;
     private final Resources resources;
-    private final DateFormat countdownTimeFormat;
+    private final TimeFormatFactory countdownTimeFormatFactory;
 
     /**
      * Constructs an instance of {@link CountdownNotifier}.
@@ -49,7 +49,7 @@ public class CountdownNotifier {
                 context,
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE),
                 context.getResources(),
-                DateFormat.getTimeInstance(DateFormat.SHORT)
+                new TimeFormatFactory(context)
         );
     }
 
@@ -60,18 +60,18 @@ public class CountdownNotifier {
      * @param context The context
      * @param notificationManager The system notification manager
      * @param resources The app's resources
-     * @param countdownTimeFormat The time format to use for the countdown
+     * @param countdownTimeFormatFactory Produces the time format to use for the countdown
      */
     CountdownNotifier(
             Context context,
             NotificationManager notificationManager,
             Resources resources,
-            DateFormat countdownTimeFormat) {
+            TimeFormatFactory countdownTimeFormatFactory) {
 
         this.context = context.getApplicationContext();
         this.notificationManager = notificationManager;
         this.resources = resources;
-        this.countdownTimeFormat = countdownTimeFormat;
+        this.countdownTimeFormatFactory = countdownTimeFormatFactory;
     }
 
     /**
@@ -107,7 +107,8 @@ public class CountdownNotifier {
      * @return A {@link Notification}
      */
     private Notification getNotification(Date countdownEnds) {
-        String countdownEndsString = countdownTimeFormat.format(countdownEnds);
+        DateFormat timeFormat = countdownTimeFormatFactory.getTimeFormat();
+        String countdownEndsString = timeFormat.format(countdownEnds);
         String title = resources.getString(R.string.countdown_notification_title);
         String text = resources.getString(R.string.countdown_notification_text, countdownEndsString);
 
@@ -144,5 +145,32 @@ public class CountdownNotifier {
      */
     public void cancelNotification() {
         notificationManager.cancel(NOTIFICATION_ID);
+    }
+
+
+    /**
+     * Produces time formats according to the system's 12/24-hour clock preference.
+     */
+    public static class TimeFormatFactory {
+
+        private final Context context;
+
+        /**
+         * Constructs an instance of {@link TimeFormatFactory}.
+         *
+         * @param context The context
+         */
+        public TimeFormatFactory(Context context) {
+            this.context = context;
+        }
+
+        /**
+         * Returns a time format according to the system's current 12/24-hour clock preference.
+         *
+         * @return A {@link DateFormat}
+         */
+        public DateFormat getTimeFormat() {
+            return android.text.format.DateFormat.getTimeFormat(context);
+        }
     }
 }


### PR DESCRIPTION
Showing the scheduled date and time is unnecessary; since a countdown will always be less than a day, showing only the time component is unambiguous and sufficient.  Uses the system's 12-/24-hour clock preference to format the time.
